### PR TITLE
fix for "12:MMam" format

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,6 +307,7 @@ function nday (s) {
 function parseh (s, next) {
     var m = /(\d+\.?\d*)(?:[:h](\d+\.?\d*)(?:[:m](\d+\.?\d*s?\.?\d*))?)?/.exec(s);
     var hms = [ Number(m[1]), null, null ];
+    if (/^am/.test(next) && hms[0] == 12) hms[0] -= 12;
     if (/^pm/.test(next) && hms[0] < 12) hms[0] += 12;
     if (m[2]) hms[1] = Number(m[2]);
     if (m[3]) hms[2] = Number(m[3]);

--- a/test/parse.js
+++ b/test/parse.js
@@ -11,6 +11,7 @@ test('parse dates', function (t) {
     
     t.equal(strftime('%T', parse('11am')), '11:00:00');
     t.equal(strftime('%T', parse('11pm')), '23:00:00');
+    t.equal(strftime('%T', parse('12:30am')), '00:30:00');
     t.equal(strftime('%T', parse('12:30pm')), '12:30:00');
     t.equal(
         strftime('%F %T', parse('tomorrow at 7')),


### PR DESCRIPTION
Found an edge case for `12:30am` and other minutes in that hour.

Wonderful library, thanks :smiley: 